### PR TITLE
Updated D116 printer type to reflect upgrade of printer

### DIFF
--- a/printer.js
+++ b/printer.js
@@ -12,7 +12,7 @@ var printerList = {
 	},
 	"D116": {
 		hostName: "D116",
-		type: "9040"
+		type: "M806"
 	},
 	"bl113-ps": {
 		hostName: "bl113-ps",


### PR DESCRIPTION
D116 has been upgraded from a 9040 to an M806. I believe this correction will now make the printer monitor work correctly.